### PR TITLE
HTTP POST strings fail integer validation

### DIFF
--- a/api/controllers/Subnets.php
+++ b/api/controllers/Subnets.php
@@ -43,10 +43,10 @@ class Subnets
 		$subnet->description	  	= $this->_params['description'];
 		$subnet->vrfId			  	= $this->_params['vrfId'];
 		$subnet->vlanId			  	= $this->_params['vlanId'];
-		$subnet->allowRequests		= $this->_params['allowRequests'];
-		$subnet->showName			= $this->_params['showName'];
+		$subnet->allowRequests		= intval($this->_params['allowRequests']);
+		$subnet->showName			= intval($this->_params['showName']);
 		$subnet->permissions		= $this->_params['permissions'];
-		$subnet->pingSubnet			= $this->_params['pingSubnet'];
+		$subnet->pingSubnet			= intval($this->_params['pingSubnet']);
 
 		//create section
 		$res = $subnet->createSubnet(); 	


### PR DESCRIPTION
https://github.com/enovance/phpipam/blob/master/api/models/subnet.php includes the following validation:

if($this->allowRequests != 0 || $this->allowRequests !=1)                                { throw new Exception('Invalid allow requests value'); }
if($this->showName != 0 || $this->showName !=1)                                                        { throw new Exception('Invalid show Name value'); }
if($this->pingSubnet != 0 || $this->pingSubnet !=1)                                                { throw new Exception('Invalid ping subnet value'); }

These validations will always fail since HTTP POST variables are strings.
