### PR TITLE
Addresses now usable with web API

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,7 +1,7 @@
 RewriteEngine on
 
 # change rewrite base if not in root
-RewriteBase /
+RewriteBase /phpipam/
 
 # api
 RewriteRule ^(api)($|/) - [L]

--- a/api/controllers/Addresses.php
+++ b/api/controllers/Addresses.php
@@ -30,7 +30,7 @@ class Addresses
 	/** 
 	* create new address 
 	*/
-	public function createAddresses($_params)
+	public function createAddresses()
 	{
 		//init section class
                 // id

--- a/api/controllers/Addresses.php
+++ b/api/controllers/Addresses.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ *	phpIPAM API class to work with addresses
+ *
+ * Reading addresses:
+ *	get by id: 	?controller=addresses&action=read&id=1
+ *	get by name: 	?controller=addresses&action=read&name=address name
+ *	get all:	?controller=addresses&action=read&all=true
+ */
+
+class Addresses
+{
+	/* variables */
+	private $_params;
+	
+	/* set parameters, provided via post */
+	public function __construct($params)
+	{
+		$this->_params = $params;
+		
+		//ip address format, can be decimal or ip
+		if(!$this->_params['format']){ $this->_params['format'] = "decimal"; }
+		//verify IP address format
+		if(!($this->_params['format']=="decimal" || $this->_params['format']== "ip")) {
+			throw new Exception('Invalid format');
+		}
+	}
+
+	/** 
+	* create new address 
+	*/
+	public function createAddresses($_params)
+	{
+		//init section class
+                // id
+                // subnetId
+                // ip_addr
+                // description
+                // dns_name
+                // mac
+                // owner
+                // state
+                // switch
+                // port
+                // note
+                // lastSeen
+                // excludePing
+                // editDate
+		$address = new Address();
+		//required parameters
+		$address->action      		= $this->_params['action'];
+		$address->subnetId        	= $this->_params['subnetId'];
+		$address->ip_addr 		= $this->_params['ip_addr'];
+		$address->description	  	= $this->_params['description'];
+		$address->dns_name		= $this->_params['dns_name'];
+		$address->mac	  		= $this->_params['mac'];
+		$address->owner			= $this->_params['owner'];
+		$address->state			= $this->_params['state'];
+		$address->switch		= $this->_params['switch'];
+		$address->port			= $this->_params['port'];
+		$address->note			= $this->_params['note'];
+		$address->lastSeen		= $this->_params['lastSeen'];
+		$address->excludePing		= $this->_params['excludePing'];
+		$address->editDate		= $this->_params['editDate'];
+
+		//create section
+		$res = $address->createAddress(); 	
+		//return result
+		return $res;
+	}
+
+
+	/** 
+	* read addresses 
+	*/
+	public function readAddresses()
+	{
+		//init address class
+		$address = new Address();
+		
+		//set IP address format
+		$address->format = $this->_params['format'];
+		
+		//get all addresses
+		if($this->_params['all']){ $address->all = true; }
+		//get all addresses in address
+		elseif($this->_params['subnetId']) { $address->subnetId = $this->_params['subnetId']; }
+		//get address by ID
+		else { $address->id = $this->_params['id']; }
+		
+		//fetch results
+		$res = $address->getAddress(); 
+		
+		//return address(s) in array format
+		return $res;
+	}	
+	
+	
+	/** 
+	* update existing address 
+	*/
+	public function updateAddresses()
+	{
+		/* not yet implementes */
+		throw new Exception('Action not yet implemented');
+	}	
+	
+	
+	/** 
+	* delete address 
+	*/
+	public function deleteAddresses()
+	{
+		/* not yet implementes */
+		throw new Exception('Action not yet implemented');
+	}
+}
+
+?>

--- a/api/index.php
+++ b/api/index.php
@@ -16,6 +16,7 @@ $settings = getAllSettings();
 /* include models */
 include_once 'models/section.php';						//section actions
 include_once 'models/subnet.php';						//subnet actions
+include_once 'models/address.php';						//address actions
 
 
 /* wrap in a try-catch block to catch exceptions */

--- a/api/models/address.php
+++ b/api/models/address.php
@@ -104,10 +104,10 @@ class Address
         // excludePing
         // editDate
         if(!isset($this->subnetId) || !is_numeric($this->subnetId))               { throw new Exception('Invalid subnet Id'); }                //mandatory parameters
-        if(!isset($this->id_addr))                                                { throw new Exception('Invalid address'); }                  //mandatory parameters
-        if($this->allowRequests != 0 || $this->allowRequests !=1)                 { throw new Exception('Invalid allow requests value'); }
-        if($this->showName != 0 || $this->showName !=1)                           { throw new Exception('Invalid show Name value'); }
-        if($this->pingAddress != 0 || $this->pingAddress !=1)                     { throw new Exception('Invalid ping address value'); }
+        if(!isset($this->ip_addr))                                                { throw new Exception('Invalid address'); }                  //mandatory parameters
+        // if($this->allowRequests != 0 || $this->allowRequests !=1)                 { throw new Exception('Invalid allow requests value'); }
+        // if($this->showName != 0 || $this->showName !=1)                           { throw new Exception('Invalid show Name value'); }
+        // if($this->pingAddress != 0 || $this->pingAddress !=1)                     { throw new Exception('Invalid ping address value'); }
 
 
         //output format
@@ -115,8 +115,9 @@ class Address
         
         //create array to write new subnet
         $newAddress = $this->toArray($this, $format);
-        //create new subnet
-        $res = UpdateSubnet2 ($newSubnet, true);                                //true means from API    
+        //create new address
+        #$res = UpdateSubnet2 ($newSubnet, true);                                //true means from API    
+        $res = UpdateAddress ($newAddress, true);                                //true means from API    
         //return result (true/false)
         if(!$res)                                                                 { throw new Exception('Invalid query'); } 
         else {

--- a/api/models/address.php
+++ b/api/models/address.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ *    phpIPAM Address class
+ */
+
+class Address
+{    
+    
+    /**
+    * get address details
+    */
+    public function getAddress() {
+    
+        /**
+        * all addresses 
+        */
+        if($this->all) {
+            //get address by id
+            $res = fetchAllIPAddresses ();
+        }
+
+        /** 
+        * all addresses in subnet
+        */
+        elseif($this->subnetId) {
+            //id must be set and numberic
+            if ( is_null($this->subnetId) || !is_numeric($this->subnetId) ){ throw new Exception('Invalid subnet Id - '.$this->subnetId); }
+            //get all addresses in subnet
+            $res = fetchAddresses ($this->subnetId);
+            //throw new exception if not existing
+            if(sizeof($res)==0) {
+                //check if subnet exists
+                if(sizeof(getSubnetDetailsById ($this->subnetId))==0){ throw new Exception('Subnet not existing');    }
+            }
+        }
+        
+        /** 
+        * address by id 
+        */
+        elseif($this->id) {
+            //id must be set and numberic
+            if ( is_null($this->id) || !is_numeric($this->id) )                 { throw new Exception('Address id not existing - '.$this->id); }
+            //get address by id
+            $res = getAddressDetailsById ($this->id);
+            //throw new exception if not existing
+            if(sizeof($res)==0)                                                 { throw new Exception('Address not existing'); }
+        }
+        
+        /**
+        * address by name 
+        */
+        elseif($this->name) {
+            //id must be set and numberic
+            if ( is_null($this->name) || strlen($this->name)==0 )               { throw new Exception('Invalid address name - '.$this->name); }
+            //get address by id
+            $res = getAddressDetailsByName ($this->name);
+            //throw new exception if not existing
+            if(sizeof($res)==0)                                                 { throw new Exception('Address not existing'); }
+        }
+        
+        /** 
+        * method missing 
+        */
+        else                                                                    { throw new Exception('Selector missing'); }
+
+        //create object from results
+        foreach($res as $key=>$line) {
+            $this->$key = $line;
+        }
+        //output format
+        $format = $this->format;
+        //remove input parameters from output
+        unset($this->all);                                                            //remove from result array
+        unset($this->format);
+        unset($this->name);    
+        unset($this->id);
+        unset($this->subnetId);    
+        //convert object to array
+        $result = $this->toArray($this, $format);    
+        //return result
+        return $result;
+    }
+
+
+    /**
+    * create new address
+    */
+
+    public function createAddress() {
+        # verications
+        // id
+        // subnetId
+        // ip_addr
+        // description
+        // dns_name
+        // mac
+        // owner
+        // state
+        // switch
+        // port
+        // note
+        // lastSeen
+        // excludePing
+        // editDate
+        if(!isset($this->subnetId) || !is_numeric($this->subnetId))               { throw new Exception('Invalid subnet Id'); }                //mandatory parameters
+        if(!isset($this->id_addr))                                                { throw new Exception('Invalid address'); }                  //mandatory parameters
+        if($this->allowRequests != 0 || $this->allowRequests !=1)                 { throw new Exception('Invalid allow requests value'); }
+        if($this->showName != 0 || $this->showName !=1)                           { throw new Exception('Invalid show Name value'); }
+        if($this->pingAddress != 0 || $this->pingAddress !=1)                     { throw new Exception('Invalid ping address value'); }
+
+
+        //output format
+        $format = $this->format;
+        
+        //create array to write new subnet
+        $newAddress = $this->toArray($this, $format);
+        //create new subnet
+        $res = UpdateSubnet2 ($newSubnet, true);                                //true means from API    
+        //return result (true/false)
+        if(!$res)                                                                 { throw new Exception('Invalid query'); } 
+        else {
+            //format response
+            return "Address created";        
+        }
+    }
+    
+
+    /**
+    * function to return multidimensional array
+    */
+    public function toArray($obj, $format)
+    {
+        //if object create array
+        if(is_object($obj)) $obj = (array) $obj;
+        if(is_array($obj)) {
+            $arr = array();
+            foreach($obj as $key => $val) {
+                // proper format
+                if($key=="ip_addr" && $format=="ip") {
+                    $val = transform2long($val);
+                }
+                // output format
+                $arr[$key] = $this->toArray($val, $format);
+            }
+        }
+        else { 
+            $arr = $obj;
+        }
+        //return an array of items
+        return $arr;
+    }
+}

--- a/config.php
+++ b/config.php
@@ -3,8 +3,8 @@
 /* database connection details
 *******************************/
 $db['host'] = "localhost";
-$db['user'] = "phpipam";
-$db['pass'] = "phpipamadmin";
+$db['user'] = "root";
+$db['pass'] = "turtoise";
 $db['name'] = "phpipam";
 
 /* glpi database connection details
@@ -42,6 +42,6 @@ $debugging = false;
  *  Also change 
  *	RewriteBase / in .htaccess
  ******************************/
-define('BASE', "/");
+define('BASE', "/phpipam/");
 
 ?>

--- a/functions/functions-network.php
+++ b/functions/functions-network.php
@@ -319,6 +319,28 @@ function getNumberOfSections ()
     return($sections[0]['count']);
 }
 
+/**
+ * Get ip details - provide address id
+ */
+function getAddressDetailsById ($id)
+{
+    global $db;                                                                      # get variables from config file
+    /* set query, open db connection and fetch results */
+    $query 	  = 'select * from ipaddresses where id = "'. $id .'";';
+    $database = new database($db['host'], $db['user'], $db['pass'], $db['name']);
+
+    /* execute */
+    try { $addresses = $database->getArray( $query ); }
+    catch (Exception $e) { 
+        $error =  $e->getMessage(); 
+        print ("<div class='alert alert-danger'>"._('Error').": $error</div>");
+        return false;
+    } 
+    $database->close();
+
+    /* return section */
+    if(sizeof($addresses) > 0)	{ return($addresses[0]); }
+}
 
 /**
  * Get section details - provide section id


### PR DESCRIPTION
You can now get addresses in web API (all / by subnet id).
Example of use (in python) : https://github.com/gloaec/python-phpipam

Note : You shouldn’t write in your documentation the controllers that are not available in the API ( only sections and subnets are so far )
